### PR TITLE
Add option to specify dns server used to resolve hostname of targets

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	pingInterval  = flag.Duration("ping.interval", time.Duration(5)*time.Second, "Interval for ICMP echo requests")
 	pingTimeout   = flag.Duration("ping.timeout", time.Duration(4)*time.Second, "Timeout for ICMP echo request")
 	dnsRefresh    = flag.Duration("dns.refresh", time.Duration(1)*time.Minute, "Interval for refreshing DNS records and updating targets accordingly (0 if disabled)")
+        dnsNameServer = flag.String("dns.nameserver", "", "DNS server used to resolve hostname of targets")
 )
 
 func init() {
@@ -81,13 +82,13 @@ func startMonitor(cfg *config.Config) (*mon.Monitor, error) {
 	}
 
 	monitor := mon.New(pinger, *pingInterval, *pingTimeout)
-
 	targets := make([]*target, len(cfg.Targets))
 	for i, host := range cfg.Targets {
 		t := &target{
 			host:      host,
 			addresses: make([]net.IP, 0),
 			delay:     time.Duration(10*i) * time.Millisecond,
+                        dns:       *dnsNameServer,
 		}
 		targets[i] = t
 


### PR DESCRIPTION
First, great job for this exporter ! This is exactly what we need for our network connectivity monitoring.

During exporter set up, we encountered a problem  specific to our network configuration : the last DNS server specified in our resolv.conf resolves public IP instead of private IP for fallback purpose.

It appears Go's default resolver seems to take any DNS server in resolv.conf: that resulted on some IP's flapping issues.

As we just want to check private network connectivity, I added this option to define DNS server used for resolve targets hostnames.
