### PR TITLE
Goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 ping_exporter
+artifacts

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+dist: artifacts
+before:
+   hooks:
+     # you may remove this if you don't use vgo
+     - go mod download
+builds:
+  -
+    env:
+    - CGO_ENABLED=0
+    goos:
+    - linux
+    - darwin
+    goarch:
+    - amd64
+    main: .
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    binary: ping_exporter
+archive:
+  format: tar.gz
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    amd64: x86_64
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+nfpm:
+  vendor: Daniel Czerwonk
+  homepage: "https://github.com/czerwonk/ping_exporter"
+  maintainer: Daniel Czerwonk
+  description: "Ping prometheus exporter"
+  license: MIT
+  formats:
+    - rpm
+    - deb
+  bindir: /usr/bin
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 go:
-  - 1.9
+  - 1.11

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
-	github.com/czerwonk/ping_exporter v0.0.0-20181111181321-eed8f09ace8b
 	github.com/digineo/go-ping v0.0.0-20181023230134-8e2c4a96fb5c
 	github.com/golang/protobuf v1.2.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1


### PR DESCRIPTION
I've used goreleaser a lot to automatically create binaries/RPMs. I'm submitting this in case you think it's useful. If not, I'm happy to maintain a fork.

This also includes the changes in #12 so that needs to be merged first.

You can build binaries against tags using:

```
goreleaser --rm-dir --skip-publish
```

If you want to have tags built automatically, I can send another PR with travis config. Examples are here: https://github.com/jaxxstorm/ping_exporter/commits/travis

You'll just need to update your travis config with this repos github token.

Let me know what you think.