### PR TITLE
Support configurable ICMP payload size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 *.iml
 ping_exporter
+ping_exporter.exe
 artifacts

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 		Interval duration `yaml:"interval"`
 		Timeout  duration `yaml:"timeout"`
 		History  int      `yaml:"history-size"`
+		Size     uint16   `yaml:"payload-size"`
 	} `yaml:"ping"`
 
 	DNS struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,5 +49,8 @@ func TestParseConfig(t *testing.T) {
 	if expected := 42; c.Ping.History != expected {
 		t.Errorf("expected ping.history-size to be %d, got %d", expected, c.Ping.History)
 	}
+	if expected := 120; c.Ping.Size != uint16(expected) {
+		t.Errorf("expected ping.payload-size to be %d, got %d", expected, c.Ping.Size)
+	}
 
 }

--- a/config/testdata/config_test.yml
+++ b/config/testdata/config_test.yml
@@ -13,3 +13,4 @@ ping:
   interval: 2s
   timeout: 3s
   history-size: 42
+  payload-size: 120

--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ func main() {
 		kingpin.FatalUsage("ping.history-size must be greater than 0")
 	}
 
-	if cfg.Ping.Size < 0 {
-		kingpin.FatalUsage("ping.size must be greater than on equal to 0")
+	if cfg.Ping.Size < 0 || cfg.Ping.Size > 65500 {
+		kingpin.FatalUsage("ping.size must be between 0 and 65500")
 	}
 
 	if len(cfg.Targets) == 0 {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	configFile    = kingpin.Flag("config.path", "Path to config file").Default("").String()
 	pingInterval  = kingpin.Flag("ping.interval", "Interval for ICMP echo requests").Default("5s").Duration()
 	pingTimeout   = kingpin.Flag("ping.timeout", "Timeout for ICMP echo request").Default("4s").Duration()
+	pingSize      = kingpin.Flag("ping.size", "Payload size for ICMP echo requests").Default("56").Uint16()
 	historySize   = kingpin.Flag("ping.history-size", "Number of results to remember per target").Default("10").Int()
 	dnsRefresh    = kingpin.Flag("dns.refresh", "Interval for refreshing DNS records and updating targets accordingly (0 if disabled)").Default("1m").Duration()
 	dnsNameServer = kingpin.Flag("dns.nameserver", "DNS server used to resolve hostname of targets").Default("").String()
@@ -83,6 +84,10 @@ func main() {
 		kingpin.FatalUsage("ping.history-size must be greater than 0")
 	}
 
+	if cfg.Ping.Size < 0 {
+		kingpin.FatalUsage("ping.size must be greater than on equal to 0")
+	}
+
 	if len(cfg.Targets) == 0 {
 		kingpin.FatalUsage("No targets specified")
 	}
@@ -108,6 +113,10 @@ func startMonitor(cfg *config.Config) (*mon.Monitor, error) {
 	pinger, err := ping.New("0.0.0.0", "::")
 	if err != nil {
 		return nil, err
+	}
+
+	if pinger.PayloadSize() != cfg.Ping.Size {
+		pinger.SetPayloadSize(cfg.Ping.Size)
 	}
 
 	monitor := mon.New(pinger,
@@ -224,6 +233,9 @@ func addFlagToConfig(cfg *config.Config) {
 	}
 	if cfg.Ping.Timeout == 0 {
 		cfg.Ping.Timeout.Set(*pingTimeout)
+	}
+	if cfg.Ping.Size == 0 {
+		cfg.Ping.Size = *pingSize
 	}
 	if cfg.DNS.Refresh == 0 {
 		cfg.DNS.Refresh.Set(*dnsRefresh)


### PR DESCRIPTION
Introduce additional `--payload-size` parameter, which allows customizing the ICMP payload size.

The default value is `56` (which, together with headers, results in `64 bytes`). It matches the default value of [`go-ping`](https://github.com/digineo/go-ping/blob/master/pinger.go#L67), so it does not affect the existing users.