### PR TITLE
Switch RTT metrics to use seconds instead of milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ $ ./ping_exporter --dns.nameserver=1.1.1.1:53 [other options]
 
 ### Exported metrics
 
-- `ping_rtt_best_ms`:          Best round trip time in millis
-- `ping_rtt_worst_ms`:         Worst round trip time in millis
-- `ping_rtt_mean_ms`:          Mean round trip time in millis
-- `ping_rtt_std_deviation_ms`: Standard deviation in millis
-- `ping_loss_percent`:         Packet loss in percent
+- `ping_rtt_best_seconds`:          Best round trip time in seconds
+- `ping_rtt_worst_seconds`:         Worst round trip time in seconds
+- `ping_rtt_mean_seconds`:          Mean round trip time in seconds
+- `ping_rtt_std_deviation_seconds`: Standard deviation in seconds
+- `ping_loss_percent`:              Packet loss in percent
 
 Each metric has labels `ip` (the target's IP address), `ip_version`
 (4 or 6, corresponding to the IP version), and `target` (the target's

--- a/collector.go
+++ b/collector.go
@@ -13,10 +13,10 @@ const prefix = "ping_"
 var (
 	labelNames = []string{"target", "ip", "ip_version"}
 	rttDesc    = prometheus.NewDesc(prefix+"rtt_ms", "Round trip time in millis (deprecated)", append(labelNames, "type"), nil)
-	bestDesc   = prometheus.NewDesc(prefix+"rtt_best_ms", "Best round trip time in millis", labelNames, nil)
-	worstDesc  = prometheus.NewDesc(prefix+"rtt_worst_ms", "Worst round trip time in millis", labelNames, nil)
-	meanDesc   = prometheus.NewDesc(prefix+"rtt_mean_ms", "Mean round trip time in millis", labelNames, nil)
-	stddevDesc = prometheus.NewDesc(prefix+"rtt_std_deviation_ms", "Standard deviation in millis", labelNames, nil)
+	bestDesc   = prometheus.NewDesc(prefix+"rtt_best_seconds", "Best round trip time in seconds", labelNames, nil)
+	worstDesc  = prometheus.NewDesc(prefix+"rtt_worst_seconds", "Worst round trip time in seconds", labelNames, nil)
+	meanDesc   = prometheus.NewDesc(prefix+"rtt_mean_seconds", "Mean round trip time in seconds", labelNames, nil)
+	stddevDesc = prometheus.NewDesc(prefix+"rtt_std_deviation_seconds", "Standard deviation in seconds", labelNames, nil)
 	lossDesc   = prometheus.NewDesc(prefix+"loss_percent", "Packet loss in percent", labelNames, nil)
 	progDesc   = prometheus.NewDesc(prefix+"up", "ping_exporter version", nil, prometheus.Labels{"version": version})
 	mutex      = &sync.Mutex{}
@@ -60,10 +60,10 @@ func (p *pingCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(rttDesc, prometheus.GaugeValue, float64(metrics.StdDev), append(l, "std_dev")...)
 			}
 
-			ch <- prometheus.MustNewConstMetric(bestDesc, prometheus.GaugeValue, float64(metrics.Best), l...)
-			ch <- prometheus.MustNewConstMetric(worstDesc, prometheus.GaugeValue, float64(metrics.Worst), l...)
-			ch <- prometheus.MustNewConstMetric(meanDesc, prometheus.GaugeValue, float64(metrics.Mean), l...)
-			ch <- prometheus.MustNewConstMetric(stddevDesc, prometheus.GaugeValue, float64(metrics.StdDev), l...)
+			ch <- prometheus.MustNewConstMetric(bestDesc, prometheus.GaugeValue, float64(metrics.Best / 1000), l...)
+			ch <- prometheus.MustNewConstMetric(worstDesc, prometheus.GaugeValue, float64(metrics.Worst / 1000), l...)
+			ch <- prometheus.MustNewConstMetric(meanDesc, prometheus.GaugeValue, float64(metrics.Mean / 1000), l...)
+			ch <- prometheus.MustNewConstMetric(stddevDesc, prometheus.GaugeValue, float64(metrics.StdDev / 1000), l...)
 		}
 
 		loss := float64(metrics.PacketsLost) / float64(metrics.PacketsSent)


### PR DESCRIPTION
As per [official Prometheus guidelines](https://prometheus.io/docs/practices/naming/#base-units), switching non-deprecated RTT metrics units from milliseconds to seconds and updating documentation accordingly.

Solves #16. As it's a breaking change, it should be released as part of a new major version.