### PR TITLE
Gracefully handle systems that have ipv4/ipv6 disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,18 @@ func printVersion() {
 
 func startMonitor(cfg *config.Config) (*mon.Monitor, error) {
 	resolver := setupResolver(cfg)
-	pinger, err := ping.New("0.0.0.0", "::")
+	var bind4,bind6 string
+	if ln, err := net.Listen("tcp4", "127.0.0.1:0"); err == nil {
+                //ipv4 enabled
+		ln.Close()
+		bind4 = "0.0.0.0"
+	}
+	if ln, err := net.Listen("tcp6", "[::1]:0"); err == nil {
+		//ipv6 enabled
+		ln.Close()
+		bind6 = "::"
+	}
+	pinger, err := ping.New(bind4, bind6)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently on our system where ipv6 is disabled the exporter fails to start with:
```
msg="listen ip6:ipv6-icmp ::: socket: address family not supported by protocol" source="main.go:97"
```

I've taken the code to detect ipv4/6 availability from here: https://github.com/golang/net/blob/ca1201d0de80cfde86cb01aea620983605dfe99b/nettest/nettest.go#L37-L44