### PR TITLE
Added snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ping_exporter
 ping_exporter.exe
 artifacts
+
+# snap
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: ping-exporter
+base: core18
+version: git
+summary: A Prometheus exporter for measuring latency to servers using ICMP ping
+description: |
+    ping_exporter uses the go-ping library to measure network latency to configured
+    hosts, as an indicator of connection quality. This data is made available (exported)
+    to prometheus, where it is stored and can be charted and queried over time.
+
+grade: stable
+confinement: strict
+
+apps:
+  daemon:
+    plugs:
+      - network
+      - network-bind
+      - network-control  # for raw socket support
+    command: ping_exporter --config.path=$SNAP_COMMON/config.yaml
+    daemon: simple
+
+parts:
+  speedtest-exporter:
+    plugin: go
+    source: .


### PR DESCRIPTION
This merge adds support for building this package as a snapcraft package.

This allows easy build and distribution on multiple Linux distributions. Automatic build and publishing can be configured on the snapcraft store also, by registering this project and then registering this repository with the package on the store, allowing tagged builds to be released as snap packages folks can install via `snap install` on their machines.

I have configured the daemon used by the snap to look in $SNAP_COMMON for the config.yaml file - this is standard practice, as snapd (the snapcraft runtime) pointed $SNAP_COMMON at a folder accessible both inside and outside the snap, typically under /var/snap/<snapname>/common - which is retained between upgrades (refreshes) of the snap.