### PR TITLE
Add web.listen-address to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ ENV CONFIG_FILE "/config"
 RUN apk --no-cache add ca-certificates
 WORKDIR /app
 COPY --from=builder /go/bin/ping_exporter .
-CMD ./ping_exporter --config.path $CONFIG_FILE
+CMD ./ping_exporter --config.path $CONFIG_FILE --web.listen-address 0.0.0.0:9247
 EXPOSE 9427

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ https://hub.docker.com/r/czerwonk/ping_exporter
 To run the ping_exporter as a Docker container, run:
 
 ```console
-$ docker run -p 9427:9427 -v ./config:/config:ro --name ping_exporter czerwonk/ping_exporter
+$ docker run -p 9427:9427 -v ./path_to_config.yml:/config:ro --name ping_exporter czerwonk/ping_exporter
 ```
 
 


### PR DESCRIPTION
Fixes Issue #31 Without this, I'm unable to access the metrics endpoint from my docker host