### PR TITLE
Fix defaults when using config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func loadConfig() (*config.Config, error) {
 	defer f.Close()
 
 	cfg, err := config.FromYAML(f)
-	if err != nil {
+	if err == nil {
 		addFlagToConfig(cfg)
 	}
 	return cfg, err


### PR DESCRIPTION
There's a small logic error when loading the config file: The flags are only applied when the loading failed.