### PR TITLE
metrics: allow for best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ targets:
   - 2001:4860:4860::8888
   - 2001:4860:4860::8844
   - google.com
-  
+
 dns:
   refresh: 2m15s
   nameserver: 1.1.1.1
@@ -60,6 +60,33 @@ name).
 
 Additionally, a `ping_up` metric reports whether the exporter
 is running (and in which version).
+
+#### Different time unit
+
+The `*_ms` metrics actually violate the recommendations by
+[Prometheus](https://prometheus.io/docs/practices/naming/#base-units),
+whereby time values should be expressed in seconds (not milliseconds).
+
+To accomodate for this, we've added a command line switch to select
+the proper scale:
+
+```console
+$ # keep using millis
+$ ./ping_exporter --metrics.rttunit=ms [other options]
+$ # use seconds instead
+$ ./ping_exporter --metrics.rttunit=s [other options]
+$ # use both millis and seconds
+$ ./ping_exporter --metrics.rttunit=both [other options]
+```
+
+For the foreseeable future, the default is `--metrics.rttunit=ms`.
+
+If you used the `ping_exporter` in the past, and want to migrate, start
+using `--metrics.rttunit=both` now. This gives you the opportunity to
+update all your alerts, dashboards, and other software depending on ms
+values to use proper scale (you "just" need to apply a factor of 1000
+on everything). When you're ready, you just need to switch to
+`--metrics.rttunit=s`.
 
 #### Deprecated metrics
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,9 @@ var (
 var (
 	enableDeprecatedMetrics = true // default may change in future
 	deprecatedMetrics       = kingpin.Flag("metrics.deprecated", "Enable or disable deprecated metrics (`ping_rtt_ms{type=best|worst|mean|std_dev}`). Valid choices: [enable, disable]").Default("enable").String()
+
+	rttMetricsScale = rttInMills // might change in future
+	rttMode         = kingpin.Flag("metrics.rttunit", "Export ping results as either millis (default), or seconds (best practice), or both (for migrations). Valid choices: [ms, s, both]").Default("ms").String()
 )
 
 func init() {
@@ -65,6 +68,11 @@ func main() {
 	default:
 		kingpin.FatalUsage("metrics.deprecated must be `enable` or `disable`")
 	}
+
+	if rttMetricsScale = rttUnitFromString(*rttMode); rttMetricsScale == rttInvalid {
+		kingpin.FatalUsage("metrics.rttunit must be `ms` for millis, or `s` for seconds, or `both`")
+	}
+	log.Infof("rtt units: %#v", rttMetricsScale)
 
 	if mpath := *metricsPath; mpath == "" {
 		log.Warnln("web.telemetry-path is empty, correcting to `/metrics`")

--- a/rttscale.go
+++ b/rttscale.go
@@ -1,0 +1,55 @@
+package main
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type rttUnit int
+
+const (
+	rttInvalid rttUnit = iota
+	rttInMills
+	rttInSeconds
+	rttBoth
+)
+
+func rttUnitFromString(s string) rttUnit {
+	switch s {
+	case "s":
+		return rttInSeconds
+	case "ms":
+		return rttInMills
+	case "both":
+		return rttBoth
+	default:
+		return rttInvalid
+	}
+}
+
+type scaledMetrics struct {
+	Millis  *prometheus.Desc
+	Seconds *prometheus.Desc
+}
+
+func (s *scaledMetrics) Describe(ch chan<- *prometheus.Desc) {
+	if rttMetricsScale == rttInMills || rttMetricsScale == rttBoth {
+		ch <- s.Millis
+	}
+	if rttMetricsScale == rttInSeconds || rttMetricsScale == rttBoth {
+		ch <- s.Seconds
+	}
+}
+
+func (s *scaledMetrics) Collect(ch chan<- prometheus.Metric, value float32, labelValues ...string) {
+	if rttMetricsScale == rttInMills || rttMetricsScale == rttBoth {
+		ch <- prometheus.MustNewConstMetric(s.Millis, prometheus.GaugeValue, float64(value), labelValues...)
+	}
+	if rttMetricsScale == rttInSeconds || rttMetricsScale == rttBoth {
+		ch <- prometheus.MustNewConstMetric(s.Seconds, prometheus.GaugeValue, float64(value)/1000, labelValues...)
+	}
+}
+
+func newScaledDesc(name, help string, variableLabels []string) scaledMetrics {
+	return scaledMetrics{
+		Millis:  newDesc(name+"_ms", help+" in millis (deprecated)", variableLabels, nil),
+		Seconds: newDesc(name+"_seconds", help+" in seconds", variableLabels, nil),
+	}
+}


### PR DESCRIPTION
To quote #16:

> To follow the [official Prometheus guidelines](https://prometheus.io/docs/practices/naming/#base-units), as well as [comments from Prometheus developers](https://www.robustperception.io/who-wants-seconds), we should be using seconds as the unit for all ping_rtt metrics (e.g. `ping_rtt_best_seconds` instead of `ping_rtt_best_ms`).

This adds a flag `--metrics.rttunit=s`, to allow the user to follow those best practices.

To keep upgrading users from tripping over this change, the default units will remain millis.

Fixes: #16