### PR TITLE
Add support for various architectures and systemd versions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,96 @@
 dist: artifacts
+
 before:
-   hooks:
-     - go mod download
+  hooks:
+    - go mod download
+    - go mod tidy
+
 builds:
   - env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     goos:
-    - linux
-    - darwin
-    - freebsd
+      - linux
+      - darwin
+      - windows
+      - freebsd
     goarch:
-    - amd64
-    - arm
-    - arm64
+      - arm
+      - arm64
+      - mips
+      - mipsle
+      - mips64
+      - mips64le
+      - amd64
+    gomips:
+      - hardfloat
+      - softfloat
+    goarm:
+      - 6
+      - 7
     ignore:
-    - goos: freebsd
-      goarch: arm64
-    ldflags: -s -w -X main.version={{.Version}}
-    binary: ping_exporter 
+      # pretty sure all 64bit MIPS chips have a FPU
+      - { goarch: mips64,   gomips: softfloat }
+      - { goarch: mips64le, gomips: softfloat }
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    binary: ping_exporter
+
+archives:
+  - format: tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if eq .Mips "softfloat" }}sf{{ end }}'
+    format_overrides:
+      - goos:   windows
+        format: zip
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+nfpms:
+  - vendor:       Daniel Czerwonk
+    homepage:     "https://github.com/czerwonk/ping_exporter"
+    maintainer:   Daniel Czerwonk
+    description:  "Ping prometheus exporter"
+    license:      MIT
+    section:      net
+    priority:     extra
+
+    file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if eq .Mips "softfloat" }}sf{{ end }}'
+
+    formats:
+      - rpm # TODO: create pre/post install/remove scripts
+      - deb
+
+    bindir: /usr/bin
+
+    contents:
+      # main systemd unit
+      - src: dist/ping_exporter.service
+        dst: /lib/systemd/system/ping_exporter.service
+
+      # sample configuration
+      - src: dist/ping_exporter.yaml
+        dst: /etc/ping_exporter/config.yml
+        type: config
+
+      # systemd drop-ins, will be managed in postinstall and preremove script
+      - src: dist/ping_exporter.d/systemd-*.conf
+        dst: /usr/local/share/ping_exporter/
+
+    empty_folders:
+      - /run/systemd/system/ping_exporter.service.d
+
+    overrides:
+      deb:
+        scripts:
+          postinstall:  dist/postinstall.sh
+          preremove:    dist/preremove.sh
+          postremove:   dist/postremove.sh
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/dist/ping_exporter.d/systemd-233.conf
+++ b/dist/ping_exporter.d/systemd-233.conf
@@ -1,0 +1,3 @@
+# hardening for systemd 233+
+[Service]
+RestrictNamespaces=yes

--- a/dist/ping_exporter.d/systemd-235.conf
+++ b/dist/ping_exporter.d/systemd-235.conf
@@ -1,0 +1,3 @@
+# hardening for systemd 235+
+[Service]
+LockPersonality=yes

--- a/dist/ping_exporter.d/systemd-242.conf
+++ b/dist/ping_exporter.d/systemd-242.conf
@@ -1,0 +1,4 @@
+# hardening for systemd 242+
+[Service]
+NoNewPrivileges=yes
+ProtectHostname=true

--- a/dist/ping_exporter.d/systemd-245.conf
+++ b/dist/ping_exporter.d/systemd-245.conf
@@ -1,0 +1,4 @@
+# hardening for systemd 245+
+[Service]
+ProtectClock=true
+RestrictSUIDSGID=yes

--- a/dist/ping_exporter.service
+++ b/dist/ping_exporter.service
@@ -4,8 +4,14 @@ After=network.target
 
 [Service]
 User=ping_exporter
-ExecStart=/usr/local/bin/ping_exporter --config.path=/etc/ping_exporter/config.yml
-NoNewPrivileges=yes
+ExecStart=/usr/bin/ping_exporter --config.path=/etc/ping_exporter/config.yml
+
+# This unit assumes systemd 232, present in EdgeOS 2.0.0
+# (a derivative of Vyatta/Debian 9).
+#
+# If the ping_exporter was installed on system with a newer systemd
+# version, you'll find additional drop-ins in ping_exporter.d/.
+
 CapabilityBoundingSet=CAP_NET_RAW
 AmbientCapabilities=CAP_NET_RAW
 PrivateDevices=true
@@ -14,15 +20,10 @@ ProtectControlGroups=true
 ProtectKernelModules=yes
 ProtectKernelTunables=true
 ProtectSystem=strict
-ProtectClock=true
-ProtectHostname=true
 ProtectHome=true
 DevicePolicy=closed
-RestrictNamespaces=yes
 RestrictRealtime=yes
-RestrictSUIDSGID=yes
 MemoryDenyWriteExecute=yes
-LockPersonality=yes
 
 [Install]
 WantedBy=default.target

--- a/dist/ping_exporter.yaml
+++ b/dist/ping_exporter.yaml
@@ -1,0 +1,17 @@
+# List of target hosts (IP addresses or host names) to ping.
+targets:
+- 127.0.0.1
+
+dns:
+  # enforce a specific DNS server for host name lookups (optional,
+  # defaults to system resolver)
+  #nameserver: 1.1.1.1
+
+  # refresh interval for host name (optional)
+  #refresh: 2m45s
+
+ping:
+  interval:     2s # How often to ping a target?
+  timeout:      3s # Timeout for a single ICMP Echo Request
+  history-size: 42 # number of results to keep per target
+  payload-size: 56 # message size for ICMP Echo Requests

--- a/dist/postinstall.sh
+++ b/dist/postinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+groupadd --system ping_exporter || true
+useradd --system -d /nonexistent -s /usr/sbin/nologin -g ping_exporter ping_exporter || true
+
+chown ping_exporter /etc/ping_exporter/config.yml
+
+current_systemd_version=$(dpkg-query --showformat='${Version}' --show systemd)
+
+for v in 233 235 242 245; do
+	if dpkg --compare-versions "$current_systemd_version" ge "$v"; then
+		cp /usr/local/share/ping_exporter/systemd-$v.conf /run/systemd/system/ping_exporter.service.d/
+	fi
+done
+
+systemctl daemon-reload
+systemctl enable ping_exporter
+systemctl restart ping_exporter

--- a/dist/postremove.sh
+++ b/dist/postremove.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" != "remove" ]; then
+	exit 0
+fi
+
+systemctl daemon-reload
+userdel  ping_exporter || true
+groupdel ping_exporter 2>/dev/null || true

--- a/dist/preremove.sh
+++ b/dist/preremove.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$1" != "remove" ]; then
+	exit 0
+fi
+
+systemctl disable ping_exporter || true
+systemctl stop ping_exporter    || true
+
+for v in 233 235 242 245; do
+	rm -f /run/systemd/system/ping_exporter.service.d/systemd-$v.conf
+done


### PR DESCRIPTION
I'd like to get the ping exporter running on Ubiquiti EdgeRouter Lite devices. The platform is MIPS (MIPS64 actually), and the EdgeOS running the device is a Debian 9 derivative.

This PR adds support for that platform (for good measure, I've also added a bunch more platforms I've seen and used on network equipment).

One notable change happened to the Debian packages build by goreleaser, as they are now fully self-contained. Installing the package will:

- create an unprivileged system user (aptly named `ping_exporter`),
- copy a config file to `/etc/ping_exporter/config.yml` (a slimmed down version of the example found in the README),
- install a systemd unit, and
- start the unit.

To get the systemd unit hardening applied to both the ancient version on EdgeOS (systemd 232) as well as modern systems, I've split the systemd unit in multiple parts (drop-ins). They are first installed to `/usr/local/share/ping_exporter/` and managed by the post-install/pre-remove scripts (which will inspect the systemd version on the host system and only apply the hardening possible).

For comparison, this is what `systemctl cat ping_exporter.service` looks like:

<details><summary>with systemd 245 (e.g. Debian 10 w/ backports, Ubuntu 20.04)</summary>

```ini
# /lib/systemd/system/ping_exporter.service
[Unit]
Description=Ping Exporter
After=network.target

[Service]
User=ping_exporter
ExecStart=/usr/bin/ping_exporter --config.path=/etc/ping_exporter/config.yml

# This unit assumes systemd 232, present in EdgeOS 2.0.0
# (a derivative of Vyatta/Debian 9).
#
# If the ping_exporter was installed on system with a newer systemd
# version, you'll find additional drop-ins in ping_exporter.d/.

CapabilityBoundingSet=CAP_NET_RAW
AmbientCapabilities=CAP_NET_RAW
PrivateDevices=true
PrivateTmp=yes
ProtectControlGroups=true
ProtectKernelModules=yes
ProtectKernelTunables=true
ProtectSystem=strict
ProtectHome=true
DevicePolicy=closed
RestrictRealtime=yes
MemoryDenyWriteExecute=yes

[Install]
WantedBy=default.target

# /run/systemd/system/ping_exporter.service.d/systemd-233.conf
# hardening for systemd 233+
[Service]
RestrictNamespaces=yes

# /run/systemd/system/ping_exporter.service.d/systemd-235.conf
# hardening for systemd 235+
[Service]
LockPersonality=yes

# /run/systemd/system/ping_exporter.service.d/systemd-242.conf
# hardening for systemd 242+
[Service]
NoNewPrivileges=yes
ProtectHostname=true

# /run/systemd/system/ping_exporter.service.d/systemd-245.conf
# hardening for systemd 245+
[Service]
ProtectClock=true
RestrictSUIDSGID=yes
```

</details>
<details><summary>with systemd 241 (e.g. Debian 10 w/o backports)</summary>

```ini
# /lib/systemd/system/ping_exporter.service
[Unit]
Description=Ping Exporter
After=network.target

[Service]
User=ping_exporter
ExecStart=/usr/bin/ping_exporter --config.path=/etc/ping_exporter/config.yml

# This unit assumes systemd 232, present in EdgeOS 2.0.0
# (a derivative of Vyatta/Debian 9).
#
# If the ping_exporter was installed on system with a newer systemd
# version, you'll find additional drop-ins in ping_exporter.d/.

CapabilityBoundingSet=CAP_NET_RAW
AmbientCapabilities=CAP_NET_RAW
PrivateDevices=true
PrivateTmp=yes
ProtectControlGroups=true
ProtectKernelModules=yes
ProtectKernelTunables=true
ProtectSystem=strict
ProtectHome=true
DevicePolicy=closed
RestrictRealtime=yes
MemoryDenyWriteExecute=yes

[Install]
WantedBy=default.target

# /run/systemd/system/ping_exporter.service.d/systemd-233.conf
# hardening for systemd 233+
[Service]
RestrictNamespaces=yes

# /run/systemd/system/ping_exporter.service.d/systemd-235.conf
# hardening for systemd 235+
[Service]
LockPersonality=yes
```

</details>
<details><summary>with systemd 232 (EdgeOS 2.0.9)</summary>

```ini
# /lib/systemd/system/ping_exporter.service
[Unit]
Description=Ping Exporter
After=network.target

[Service]
User=ping_exporter
ExecStart=/usr/bin/ping_exporter --config.path=/etc/ping_exporter/config.yml

# This unit assumes systemd 232, present in EdgeOS 2.0.0
# (a derivative of Vyatta/Debian 9).
#
# If the ping_exporter was installed on system with a newer systemd
# version, you'll find additional drop-ins in ping_exporter.d/.

CapabilityBoundingSet=CAP_NET_RAW
AmbientCapabilities=CAP_NET_RAW
PrivateDevices=true
PrivateTmp=yes
ProtectControlGroups=true
ProtectKernelModules=yes
ProtectKernelTunables=true
ProtectSystem=strict
ProtectHome=true
DevicePolicy=closed
RestrictRealtime=yes
MemoryDenyWriteExecute=yes

[Install]
WantedBy=default.target
```

</details>

There's just one caveat: this is only tested on dpkg-based systems, because of the following lines in the Debian post-install hook:

```sh
current_systemd_version=$(dpkg-query --showformat='${Version}' --show systemd)

for v in 233 235 242 245; do
	if dpkg --compare-versions "$current_systemd_version" ge "$v"; then
		cp /usr/local/share/ping_exporter/systemd-$v.conf /run/systemd/system/ping_exporter.service.d/
	fi
done
```

I simply don't know how to retrofit that for RPM-based systems.