### PR TITLE
Set version via -ldflags

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,8 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "0.4.7"
+// Version is updated at compile-time via -ldflags.
+var version string = "development"
 
 var (
 	showVersion   = kingpin.Flag("version", "Print version information").Default().Bool()
@@ -189,7 +190,7 @@ func refreshDNS(targets []*target, monitor *mon.Monitor) {
 func startServer(monitor *mon.Monitor) {
 	log.Infof("Starting ping exporter (Version: %s)", version)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, indexHTML, *metricsPath)
+		fmt.Fprintf(w, indexHTML, version, *metricsPath)
 	})
 
 	reg := prometheus.NewRegistry()
@@ -273,7 +274,7 @@ const indexHTML = `<!doctype html>
 <html>
 <head>
 	<meta charset="UTF-8">
-	<title>ping Exporter (Version ` + version + `)</title>
+	<title>ping Exporter (Version %s)</title>
 </head>
 <body>
 	<h1>ping Exporter</h1>


### PR DESCRIPTION
This automates tagging/building a bit and removes duplication.

Goreleaser, by default, adds versioning information to the `go build` and `go release` call:

```console
$ goreleaser build --rm-dist --single-target --snapshot
   ...
   • getting and validating git state
      • releasing 0.4.7, commit d20774f4fa356511f93c7c5f0a8501117ddf1114
   ...

$ artifacts/ping_exporter_linux_amd64/ping_exporter --version
ping-exporter
Version: 0.4.7-SNAPSHOT-d20774f
Author(s): Philip Berndroth, Daniel Czerwonk
Metric exporter for go-icmp
```