### PR TITLE
feat: Build with CAP_NET_RAW by default to simplify rootless use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/ping_expo
 
 FROM alpine:latest
 ENV CONFIG_FILE "/config/config.yml"
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates libcap
 WORKDIR /app
 COPY --from=builder /go/bin/ping_exporter .
+RUN setcap cap_net_raw+ep /app/ping_exporter
 CMD ./ping_exporter --config.path $CONFIG_FILE
 EXPOSE 9427

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ On Linux systems `CAP_NET_RAW` is required to run `ping_exporter` as unprivilige
 # setcap cap_net_raw+ep /path/to/ping_exporter
 ```
 
+When run through a rootless Docker implementation on Linux, the flag `--cap-add=CAP_NET_RAW` should be added to the `docker run` invocation.
+
 ### Docker
 
 https://hub.docker.com/r/czerwonk/ping_exporter


### PR DESCRIPTION
See also the README regarding use.

Other than the bloat of adding `libcap` to the container being run (rather than to the builder -- I just wasn't aware what `golang:builder` was based on), are there any concerns about adding `CAP_NET_RAW` to the binary by default?