### PR TITLE
Add ability to have multiple monitors, and to change ping ID field

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -26,7 +26,7 @@ var (
 
 type pingCollector struct {
 	monitors []*mon.Monitor
-	metrics map[string]*mon.Metrics
+	metrics  map[string]*mon.Metrics
 }
 
 func (p *pingCollector) Describe(ch chan<- *prometheus.Desc) {

--- a/config/config.go
+++ b/config/config.go
@@ -13,10 +13,12 @@ type Config struct {
 	Targets []string `yaml:"targets"`
 
 	Ping struct {
-		Interval duration `yaml:"interval"`
-		Timeout  duration `yaml:"timeout"`
-		History  int      `yaml:"history-size"`
-		Size     uint16   `yaml:"payload-size"`
+		Interval          duration `yaml:"interval"`
+		Timeout           duration `yaml:"timeout"`
+		History           int      `yaml:"history-size"`
+		Size              uint16   `yaml:"payload-size"`
+		IDChangeInterval  duration `yaml:"id-change-interval"`
+		IDChangeThreshold float64  `yaml:"id-change-threshold"`
 	} `yaml:"ping"`
 
 	DNS struct {
@@ -34,10 +36,12 @@ type MonitorConfig struct {
 	Targets []string `yaml:"targets"`
 
 	Ping struct {
-		Interval duration `yaml:"interval"`
-		Timeout  duration `yaml:"timeout"`
-		History  int      `yaml:"history-size"`
-		Size     uint16   `yaml:"payload-size"`
+		Interval          duration `yaml:"interval"`
+		Timeout           duration `yaml:"timeout"`
+		History           int      `yaml:"history-size"`
+		Size              uint16   `yaml:"payload-size"`
+		IDChangeInterval  duration `yaml:"id-change-interval"`
+		IDChangeThreshold float64  `yaml:"id-change-threshold"`
 	} `yaml:"ping"`
 
 	DNS struct {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,26 @@ type Config struct {
 		Refresh    duration `yaml:"refresh"`
 		Nameserver string   `yaml:"nameserver"`
 	} `yaml:"dns"`
+
+	Monitors []MonitorConfig `yaml:"monitors"`
+}
+
+// This is the struct for a sub-entry under the `monitors` section.  We support
+// all the same fields as at the top level, except for nameserver, and
+// (obviously) not the `monitors` field within sub-entries.
+type MonitorConfig struct {
+	Targets []string `yaml:"targets"`
+
+	Ping struct {
+		Interval duration `yaml:"interval"`
+		Timeout  duration `yaml:"timeout"`
+		History  int      `yaml:"history-size"`
+		Size     uint16   `yaml:"payload-size"`
+	} `yaml:"ping"`
+
+	DNS struct {
+		Refresh    duration `yaml:"refresh"`
+	} `yaml:"dns"`
 }
 
 type duration time.Duration

--- a/config/config.go
+++ b/config/config.go
@@ -13,12 +13,15 @@ type Config struct {
 	Targets []string `yaml:"targets"`
 
 	Ping struct {
-		Interval          duration `yaml:"interval"`
-		Timeout           duration `yaml:"timeout"`
-		History           int      `yaml:"history-size"`
-		Size              uint16   `yaml:"payload-size"`
-		IDChangeInterval  duration `yaml:"id-change-interval"`
-		IDChangeThreshold float64  `yaml:"id-change-threshold"`
+		Interval duration `yaml:"interval"`
+		Timeout  duration `yaml:"timeout"`
+		History  int      `yaml:"history-size"`
+		Size     uint16   `yaml:"payload-size"`
+		IdChange struct {
+			Interval      duration `yaml:"interval"`
+			LossThreshold float64  `yaml:"loss-threshold"`
+			TimeThreshold duration `yaml:"time-threshold"`
+		} `yaml:"id-change"`
 	} `yaml:"ping"`
 
 	DNS struct {
@@ -36,16 +39,19 @@ type MonitorConfig struct {
 	Targets []string `yaml:"targets"`
 
 	Ping struct {
-		Interval          duration `yaml:"interval"`
-		Timeout           duration `yaml:"timeout"`
-		History           int      `yaml:"history-size"`
-		Size              uint16   `yaml:"payload-size"`
-		IDChangeInterval  duration `yaml:"id-change-interval"`
-		IDChangeThreshold float64  `yaml:"id-change-threshold"`
+		Interval duration `yaml:"interval"`
+		Timeout  duration `yaml:"timeout"`
+		History  int      `yaml:"history-size"`
+		Size     uint16   `yaml:"payload-size"`
+		IdChange struct {
+			Interval      duration `yaml:"interval"`
+			LossThreshold float64  `yaml:"loss-threshold"`
+			TimeThreshold duration `yaml:"time-threshold"`
+		} `yaml:"id-change"`
 	} `yaml:"ping"`
 
 	DNS struct {
-		Refresh    duration `yaml:"refresh"`
+		Refresh duration `yaml:"refresh"`
 	} `yaml:"dns"`
 }
 


### PR DESCRIPTION
[Note, this change is dependent on upstream repo changes (https://github.com/digineo/go-ping/pull/19) which haven't been merged yet, so probably should not be merged until that happens]

This PR adds some new functionality:

* It adds the ability to define multiple ping monitors with different parameters (so, for example, you can ping some targets at a different interval than others, etc).
* Allows setting the ICMP echo `identifier` field differently for different monitors, so they will generally be considered different "sessions" by NAT gateways, etc.
* Adds the ability to change the `identifier` for pings periodically, or under certain conditions (high packet loss, etc).

I mostly added these features to deal with some situations in my own networking setup which the existing code could not really handle:

I have a NAT gateway router with redundant links to the internet (a main connection, and a backup DSL connection).  Because the two outbound links use different NAT addresses, each outbound ping session gets tied to a particular interface, and all packets for that session will go out that interface, regardless of their destination, so I was unable to correctly ping both remote gateways at the same time, for example (because packets for one or the other would go out the interface for the other one).

Additionally, I discovered if something happened to the primary connection, and the gateway automatically failed over to using the backup, all the overall internet connection continued to work for everything else, but any ping targets beyond the gateway would show up as not responding (because the NAT session for that ping ID was still tied to the failed connection, and would not fail over when everything else did).  With these changes, I can now configure the ping_exporter to essentially initiate a new ping session whenever packet loss indicates something has happened to the primary connection, or just periodically change it after a certain amount of time (to account for fail-back, etc).

(Sorry this is such a big PR, but it all kinda evolved as a bunch of interrelated changes..)