### PR TITLE
Feature: disable ipv6 addresses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: "1.16"
+      GO_VERSION: "1.17"
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: "${{ matrix.platform }}"
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ping_exporter
 ping_exporter.exe
 artifacts
+.vscode/**
 
 # snap
 *.snap

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ ping:
   timeout: 3s
   history-size: 42
   payload-size: 120
+
+options:
+  disableIPv6: false
 ```
 
 Note: domains are resolved (regularly) to their corresponding A and AAAA

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,10 @@ type Config struct {
 		Refresh    duration `yaml:"refresh"`
 		Nameserver string   `yaml:"nameserver"`
 	} `yaml:"dns"`
+
+	Options struct {
+		DisableIPv6 bool `yaml:"disableIPv6"` // prohibits DNS resolved IPv6 addresses
+	} `yaml:"options"`
 }
 
 type duration time.Duration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,4 +54,7 @@ func TestParseConfig(t *testing.T) {
 	if expected := 120; c.Ping.Size != uint16(expected) {
 		t.Errorf("expected ping.payload-size to be %d, got %d", expected, c.Ping.Size)
 	}
+	if expected := true; c.Options.DisableIPv6 != expected {
+		t.Errorf("expected options.disable-ipv6 to be %v, got %v", expected, c.Options.DisableIPv6)
+	}
 }

--- a/config/testdata/config_test.yml
+++ b/config/testdata/config_test.yml
@@ -14,3 +14,6 @@ ping:
   timeout: 3s
   history-size: 42
   payload-size: 120
+
+options:
+  disableIPv6: true

--- a/main.go
+++ b/main.go
@@ -149,32 +149,32 @@ func startMonitor(cfg *config.Config) (*mon.Monitor, error) {
 		}
 		targets[i] = t
 
-		err := t.addOrUpdateMonitor(monitor)
+		err := t.addOrUpdateMonitor(monitor, cfg.Options.DisableIPv6)
 		if err != nil {
 			log.Errorln(err)
 		}
 	}
 
-	go startDNSAutoRefresh(cfg.DNS.Refresh.Duration(), targets, monitor)
+	go startDNSAutoRefresh(cfg.DNS.Refresh.Duration(), targets, monitor, cfg.Options.DisableIPv6)
 
 	return monitor, nil
 }
 
-func startDNSAutoRefresh(interval time.Duration, targets []*target, monitor *mon.Monitor) {
+func startDNSAutoRefresh(interval time.Duration, targets []*target, monitor *mon.Monitor, disableIPv6 bool) {
 	if interval <= 0 {
 		return
 	}
 
 	for range time.NewTicker(interval).C {
-		refreshDNS(targets, monitor)
+		refreshDNS(targets, monitor, disableIPv6)
 	}
 }
 
-func refreshDNS(targets []*target, monitor *mon.Monitor) {
+func refreshDNS(targets []*target, monitor *mon.Monitor, disableIPv6 bool) {
 	log.Infoln("refreshing DNS")
 	for _, t := range targets {
 		go func(ta *target) {
-			err := ta.addOrUpdateMonitor(monitor)
+			err := ta.addOrUpdateMonitor(monitor, disableIPv6)
 			if err != nil {
 				log.Errorf("could not refresh dns: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	historySize   = kingpin.Flag("ping.history-size", "Number of results to remember per target").Default("10").Int()
 	dnsRefresh    = kingpin.Flag("dns.refresh", "Interval for refreshing DNS records and updating targets accordingly (0 if disabled)").Default("1m").Duration()
 	dnsNameServer = kingpin.Flag("dns.nameserver", "DNS server used to resolve hostname of targets").Default("").String()
+	disableIPv6   = kingpin.Flag("options.disable-ipv6", "Disable DNS from resolving IPv6 AAAA records").Default().Bool()
 	logLevel      = kingpin.Flag("log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]").Default("info").String()
 	targets       = kingpin.Arg("targets", "A list of targets to ping").Strings()
 )
@@ -44,11 +45,9 @@ var (
 	rttMode         = kingpin.Flag("metrics.rttunit", "Export ping results as either millis (default), or seconds (best practice), or both (for migrations). Valid choices: [ms, s, both]").Default("ms").String()
 )
 
-func init() {
-	kingpin.Parse()
-}
-
 func main() {
+	kingpin.Parse()
+
 	if *showVersion {
 		printVersion()
 		os.Exit(0)
@@ -267,6 +266,9 @@ func addFlagToConfig(cfg *config.Config) {
 	}
 	if cfg.DNS.Nameserver == "" {
 		cfg.DNS.Nameserver = *dnsNameServer
+	}
+	if !cfg.Options.DisableIPv6 {
+		cfg.Options.DisableIPv6 = *disableIPv6
 	}
 }
 

--- a/target.go
+++ b/target.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -23,8 +24,8 @@ type target struct {
 }
 
 const (
-	ipv4 ipVersion = iota
-	ipv6
+	ipv4 ipVersion = 4
+	ipv6 ipVersion = 6
 )
 
 func (t *target) addOrUpdateMonitor(monitor *mon.Monitor) error {
@@ -100,9 +101,5 @@ func getIPVersion(addr net.IPAddr) ipVersion {
 
 // String converts ipVersion to a string represention of the IP version used (i.e. "4" or "6")
 func (ipv ipVersion) String() string {
-	if ipv == ipv6 {
-		return "6"
-	}
-
-	return "4"
+	return strconv.Itoa(int(ipv))
 }

--- a/target.go
+++ b/target.go
@@ -83,7 +83,6 @@ func (t *target) cleanUp(addr []net.IPAddr, monitor *mon.Monitor) {
 }
 
 func (t *target) add(addr net.IPAddr, monitor *mon.Monitor) error {
-	// TODO: If ipv6 disabled, check and skip
 	name := t.nameForIP(addr)
 	log.Infof("adding target for host %s (%v)", t.host, addr)
 

--- a/target_test.go
+++ b/target_test.go
@@ -128,7 +128,7 @@ func Test_target_nameForIP(t *testing.T) {
 			"testhost.com 142.250.72.206 4",
 		},
 		{
-			"ipv4-google",
+			"ipv6-google",
 			ipv6AddrGoogle[0],
 			"testhost.com 2607:f8b0:4005:810::200e 6",
 		},

--- a/target_test.go
+++ b/target_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"sync"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	ipv4Addr, ipv6Addr, ipv4AddrGoogle, ipv6AddrGoogle []net.IPAddr
+)
+
+func TestMain(m *testing.M) {
+	// --- set up test addresses ---- //
+	var err error
+	ipv4Addr, err = net.DefaultResolver.LookupIPAddr(context.TODO(), "127.0.0.1")
+	if err != nil || len(ipv4Addr) < 1 {
+		log.Fatal("skipping test, cannot resolve 127.0.0.1 to net.IPAddr")
+		return
+	}
+
+	ipv6Addr, err = net.DefaultResolver.LookupIPAddr(context.TODO(), "::1")
+	if err != nil || len(ipv6Addr) < 1 {
+		log.Fatal("skipping test, cannot resolve ::1 to net.IPAddr")
+		return
+	}
+
+	ipv4AddrGoogle, err = net.DefaultResolver.LookupIPAddr(context.TODO(), "142.250.72.206")
+	if err != nil || len(ipv4Addr) < 1 {
+		log.Fatal("skipping test, cannot resolve 142.250.72.206 to net.IPAddr")
+		return
+	}
+
+	ipv6AddrGoogle, err = net.DefaultResolver.LookupIPAddr(context.TODO(), "2607:f8b0:4005:810::200e")
+	if err != nil || len(ipv6Addr) < 1 {
+		log.Fatal("skipping test, cannot resolve 2607:f8b0:4005:810::200e to net.IPAddr")
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+func Test_ipVersion_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ipv  ipVersion
+		want string
+	}{
+		{
+			"ipv6",
+			ipv6,
+			"6",
+		},
+		{
+			"ipv4",
+			ipv4,
+			"4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ipv.String(); got != tt.want {
+				t.Errorf("IPVersion.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getIPVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.IPAddr
+		want ipVersion
+	}{
+		{
+			"ipv4",
+			ipv4Addr[0],
+			ipv4,
+		},
+		{
+			"ipv6",
+			ipv6Addr[0],
+			ipv6,
+		},
+		{
+			"ipv4-google",
+			ipv4AddrGoogle[0],
+			ipv4,
+		},
+		{
+			"ipv6-google",
+			ipv6AddrGoogle[0],
+			ipv6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getIPVersion(tt.addr); got != tt.want {
+				t.Errorf("getIPVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_target_nameForIP(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.IPAddr
+		want string
+	}{
+		{
+			"ipv4-localhost",
+			ipv4Addr[0],
+			"testhost.com 127.0.0.1 4",
+		},
+		{
+			"ipv6-localhost",
+			ipv6Addr[0],
+			"testhost.com ::1 6",
+		},
+		{
+			"ipv4-google",
+			ipv4AddrGoogle[0],
+			"testhost.com 142.250.72.206 4",
+		},
+		{
+			"ipv4-google",
+			ipv6AddrGoogle[0],
+			"testhost.com 2607:f8b0:4005:810::200e 6",
+		},
+	}
+	for _, tt := range tests {
+		tr := &target{
+			host:      "testhost.com",
+			addresses: []net.IPAddr{},
+			delay:     0,
+			resolver:  &net.Resolver{},
+			mutex:     sync.Mutex{},
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tr.nameForIP(tt.addr); got != tt.want {
+				t.Errorf("target.nameForIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I don't have IPv6 support where I am using this, so I wanted to stop the metrics coming in for all the failed IPv6 addresses.

This is a bit of a superfluous feature and, of course, the failed IPv6 metrics can just be filtered out by using the label `ip_version="4"`, but it just bothered me having useless metrics scraped in and hanging around. 

I made a new section in the config which is very generically called `options`, mostly because I couldn't think of a different heading to put this single setting under. I figure `options` could be for any future miscellaneous, uncategorized settings? 🤷