### PR TITLE
helm: add strategy and podLabels

### DIFF
--- a/dist/charts/ping-exporter/templates/deployment.yaml
+++ b/dist/charts/ping-exporter/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "ping_exporter.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount }} 
+  strategy: 
+  {{- toYaml .Values.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "ping_exporter.selectorLabels" . | nindent 6 }}
@@ -17,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "ping_exporter.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -22,6 +22,12 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
+# Rollout strategy, could be "Recreate" or "RollingUpdate"
+strategy:
+  type: RollingUpdate
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
Add:
- Support to define rollout strategy (default to RollingUpdate).
- Support to define custom podLabels (could be useful for observability purposes)