### PR TITLE
Fix example usage of ping.size

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ping:
   interval: 2s
   timeout: 3s
   history-size: 42
-  payload-size: 120
+  size: 120
 
 options:
   disableIPv6: false


### PR DESCRIPTION
From latest, the parameter is `ping.size`. With this, I get `ping_rtt_best_seconds`, `ping_rtt_mean_seconds` etc. metrics, with the existing example using `ping.payload-size` all I get is `ping_loss_ratio`.

```
docker exec -it ping_exporter /bin/sh
/app # ./ping_exporter --help
usage: ping_exporter [<flags>] [<targets>...]

Flags:
  --help                        Show context-sensitive help (also try --help-long and --help-man).
  --version                     Print version information
  --web.listen-address=":9427"  Address on which to expose metrics and web interface
  --web.telemetry-path="/metrics"  
                                Path under which to expose metrics
  --config.path=""              Path to config file
  --ping.interval=5s            Interval for ICMP echo requests
  --ping.timeout=4s             Timeout for ICMP echo request
  --ping.size=56                Payload size for ICMP echo requests
  --ping.history-size=10        Number of results to remember per target
  --dns.refresh=1m              Interval for refreshing DNS records and updating targets accordingly (0 if disabled)
  --dns.nameserver=""           DNS server used to resolve hostname of targets
  --options.disable-ipv6        Disable DNS from resolving IPv6 AAAA records
  --log.level="info"            Only log messages with the given severity or above. Valid levels: [debug, info, warn, error,
                                fatal]
  --metrics.deprecated="disable"  
                                Enable or disable deprecated metrics (`ping_rtt_ms{type=best|worst|mean|std_dev}`). Valid
                                choices: [enable, disable]
  --metrics.rttunit="s"         Export ping results as either seconds (default), or milliseconds (deprecated), or both (for
                                migrations). Valid choices: [s, ms, both]

Args:
  [<targets>]  A list of targets to ping
```