### PR TITLE
Implement hot reloading of configuration file for changed list of targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ $ # use Cloudflare's public DNS server
 $ ./ping_exporter --dns.nameserver=1.1.1.1:53 [other options]
 ```
 
+The configuration file is watched via inotify. If the configuration is changed,
+ping_exporter will update the targets. To change any global options like the ping
+interval or history size, you must restart the exporter.
+
 ### Exported metrics
 
 - `ping_rtt_best_seconds`:          Best round trip time in seconds

--- a/go.mod
+++ b/go.mod
@@ -46,4 +46,5 @@ require (
 	golang.org/x/tools v0.4.1-0.20221208213631-3f74d914ae6d // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tailscale.go
+++ b/tailscale.go
@@ -19,6 +19,6 @@ func tsDiscover() {
 	}
 
 	for _, dev := range devices {
-		*targets = append(*targets, dev.Hostname)
+		*targetFlag = append(*targetFlag, dev.Hostname)
 	}
 }


### PR DESCRIPTION
The list of targets will be changed without restarting the exporter. This will not erase the history data of other ping targets, but enables the user to have a dynamic set of targets.