### PR TITLE
Fix bugs introduced by hot reloading of targets

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -12,8 +12,18 @@ import (
 	"github.com/czerwonk/ping_exporter/config"
 )
 
-var (
-	labelNames []string
+type pingCollector struct {
+	monitor                 *mon.Monitor
+	enableDeprecatedMetrics bool
+	rttUnit                 rttUnit
+
+	cfg *config.Config
+
+	mutex sync.RWMutex
+
+	customLabels *customLabelSet
+	metrics      map[string]*mon.Metrics
+
 	rttDesc    scaledMetrics
 	bestDesc   scaledMetrics
 	worstDesc  scaledMetrics
@@ -21,39 +31,47 @@ var (
 	stddevDesc scaledMetrics
 	lossDesc   *prometheus.Desc
 	progDesc   *prometheus.Desc
-	mutex      *sync.Mutex
-)
+}
 
-type pingCollector struct {
-	cfg          *config.Config
-	customLabels *customLabelSet
-	monitor      *mon.Monitor
-	metrics      map[string]*mon.Metrics
+func NewPingCollector(enableDeprecatedMetrics bool, unit rttUnit, monitor *mon.Monitor, cfg *config.Config) *pingCollector {
+	ret := &pingCollector{
+		monitor:                 monitor,
+		enableDeprecatedMetrics: enableDeprecatedMetrics,
+		rttUnit:                 unit,
+		cfg:                     cfg,
+	}
+	ret.customLabels = newCustomLabelSet(cfg.Targets)
+	ret.createDesc()
+	return ret
+}
+
+func (p *pingCollector) UpdateConfig(cfg *config.Config) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.cfg.Targets = cfg.Targets
 }
 
 func (p *pingCollector) Describe(ch chan<- *prometheus.Desc) {
-	p.createDesc()
-
-	if enableDeprecatedMetrics {
-		rttDesc.Describe(ch)
+	if p.enableDeprecatedMetrics {
+		p.rttDesc.Describe(ch)
 	}
-	bestDesc.Describe(ch)
-	worstDesc.Describe(ch)
-	meanDesc.Describe(ch)
-	stddevDesc.Describe(ch)
-	ch <- lossDesc
-	ch <- progDesc
+	p.bestDesc.Describe(ch)
+	p.worstDesc.Describe(ch)
+	p.meanDesc.Describe(ch)
+	p.stddevDesc.Describe(ch)
+	ch <- p.lossDesc
+	ch <- p.progDesc
 }
 
 func (p *pingCollector) Collect(ch chan<- prometheus.Metric) {
-	mutex.Lock()
-	defer mutex.Unlock()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
 	if m := p.monitor.Export(); len(m) > 0 {
 		p.metrics = m
 	}
 
-	ch <- prometheus.MustNewConstMetric(progDesc, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(p.progDesc, prometheus.GaugeValue, 1)
 
 	for target, metrics := range p.metrics {
 		l := strings.SplitN(target, " ", 3)
@@ -63,35 +81,34 @@ func (p *pingCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if metrics.PacketsSent > metrics.PacketsLost {
 			if enableDeprecatedMetrics {
-				rttDesc.Collect(ch, metrics.Best, append(l, "best")...)
-				rttDesc.Collect(ch, metrics.Worst, append(l, "worst")...)
-				rttDesc.Collect(ch, metrics.Mean, append(l, "mean")...)
-				rttDesc.Collect(ch, metrics.StdDev, append(l, "std_dev")...)
+				p.rttDesc.Collect(ch, metrics.Best, append(l, "best")...)
+				p.rttDesc.Collect(ch, metrics.Worst, append(l, "worst")...)
+				p.rttDesc.Collect(ch, metrics.Mean, append(l, "mean")...)
+				p.rttDesc.Collect(ch, metrics.StdDev, append(l, "std_dev")...)
 			}
 
-			bestDesc.Collect(ch, metrics.Best, l...)
-			worstDesc.Collect(ch, metrics.Worst, l...)
-			meanDesc.Collect(ch, metrics.Mean, l...)
-			stddevDesc.Collect(ch, metrics.StdDev, l...)
+			p.bestDesc.Collect(ch, metrics.Best, l...)
+			p.worstDesc.Collect(ch, metrics.Worst, l...)
+			p.meanDesc.Collect(ch, metrics.Mean, l...)
+			p.stddevDesc.Collect(ch, metrics.StdDev, l...)
 		}
 
 		loss := float64(metrics.PacketsLost) / float64(metrics.PacketsSent)
-		ch <- prometheus.MustNewConstMetric(lossDesc, prometheus.GaugeValue, loss, l...)
+		ch <- prometheus.MustNewConstMetric(p.lossDesc, prometheus.GaugeValue, loss, l...)
 	}
 }
 
 func (p *pingCollector) createDesc() {
-	labelNames = []string{"target", "ip", "ip_version"}
+	labelNames := []string{"target", "ip", "ip_version"}
 	labelNames = append(labelNames, p.customLabels.labelNames()...)
 
-	rttDesc = newScaledDesc("rtt", "Round trip time", append(labelNames, "type"))
-	bestDesc = newScaledDesc("rtt_best", "Best round trip time", labelNames)
-	worstDesc = newScaledDesc("rtt_worst", "Worst round trip time", labelNames)
-	meanDesc = newScaledDesc("rtt_mean", "Mean round trip time", labelNames)
-	stddevDesc = newScaledDesc("rtt_std_deviation", "Standard deviation", labelNames)
-	lossDesc = newDesc("loss_ratio", "Packet loss from 0.0 to 1.0", labelNames, nil)
-	progDesc = newDesc("up", "ping_exporter version", nil, prometheus.Labels{"version": version})
-	mutex = &sync.Mutex{}
+	p.rttDesc = newScaledDesc("rtt", "Round trip time", p.rttUnit, append(labelNames, "type"))
+	p.bestDesc = newScaledDesc("rtt_best", "Best round trip time", p.rttUnit, labelNames)
+	p.worstDesc = newScaledDesc("rtt_worst", "Worst round trip time", p.rttUnit, labelNames)
+	p.meanDesc = newScaledDesc("rtt_mean", "Mean round trip time", p.rttUnit, labelNames)
+	p.stddevDesc = newScaledDesc("rtt_std_deviation", "Standard deviation", p.rttUnit, labelNames)
+	p.lossDesc = newDesc("loss_ratio", "Packet loss from 0.0 to 1.0", labelNames, nil)
+	p.progDesc = newDesc("up", "ping_exporter version", nil, prometheus.Labels{"version": version})
 }
 
 func newDesc(name, help string, variableLabels []string, constLabels prometheus.Labels) *prometheus.Desc {

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func upsertTargets(globalTargets *targets, resolver *net.Resolver, cfg *config.C
 				disableIPv6: cfg.Options.DisableIPv6,
 			})
 			if err != nil {
-				log.Errorf("failed to setup target: %w", err)
+				log.Errorf("failed to setup target: %v", err)
 			}
 			wg.Done()
 		}()

--- a/rttscale.go
+++ b/rttscale.go
@@ -29,28 +29,30 @@ func rttUnitFromString(s string) rttUnit {
 type scaledMetrics struct {
 	Millis  *prometheus.Desc
 	Seconds *prometheus.Desc
+	scale   rttUnit
 }
 
 func (s *scaledMetrics) Describe(ch chan<- *prometheus.Desc) {
-	if rttMetricsScale == rttInMills || rttMetricsScale == rttBoth {
+	if s.scale == rttInMills || s.scale == rttBoth {
 		ch <- s.Millis
 	}
-	if rttMetricsScale == rttInSeconds || rttMetricsScale == rttBoth {
+	if s.scale == rttInSeconds || s.scale == rttBoth {
 		ch <- s.Seconds
 	}
 }
 
 func (s *scaledMetrics) Collect(ch chan<- prometheus.Metric, value float32, labelValues ...string) {
-	if rttMetricsScale == rttInMills || rttMetricsScale == rttBoth {
+	if s.scale == rttInMills || s.scale == rttBoth {
 		ch <- prometheus.MustNewConstMetric(s.Millis, prometheus.GaugeValue, float64(value), labelValues...)
 	}
-	if rttMetricsScale == rttInSeconds || rttMetricsScale == rttBoth {
+	if s.scale == rttInSeconds || s.scale == rttBoth {
 		ch <- prometheus.MustNewConstMetric(s.Seconds, prometheus.GaugeValue, float64(value)/1000, labelValues...)
 	}
 }
 
-func newScaledDesc(name, help string, variableLabels []string) scaledMetrics {
+func newScaledDesc(name, help string, scale rttUnit, variableLabels []string) scaledMetrics {
 	return scaledMetrics{
+		scale:   scale,
 		Millis:  newDesc(name+"_ms", help+" in millis (deprecated)", variableLabels, nil),
 		Seconds: newDesc(name+"_seconds", help+" in seconds", variableLabels, nil),
 	}

--- a/target.go
+++ b/target.go
@@ -37,12 +37,25 @@ func (t *targets) SetTargets(tar []*target) {
 }
 
 func (t *targets) Contains(tar *target) bool {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 	for _, ta := range t.t {
 		if ta.host == tar.host {
 			return true
 		}
 	}
 	return false
+}
+
+func (t *targets) Get(host string) *target {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+	for _, ta := range t.t {
+		if ta.host == host {
+			return ta
+		}
+	}
+	return nil
 }
 
 func (t *targets) Targets() []*target {


### PR DESCRIPTION
Improve speedup time by doing the intial DNS resolution also in parallel.

Fix edge cases if big files are created and truncated.

Refactor the ping collector such that it doesn't rely on global variables anymore. Add support for updating the target configs such that the label values can be updated per target. The set of labels names is not updated, as this will break the prometheus Collector interface.