### PR TITLE
Prometheus Operator support

### DIFF
--- a/dist/charts/ping-exporter/files/prometheus.rules
+++ b/dist/charts/ping-exporter/files/prometheus.rules
@@ -1,0 +1,16 @@
+    - alert: HighPingLossRatio
+      expr: round(ping_loss_ratio * 100) > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: High ping loss ratio for {{ $labels.target }}
+        description: "Ping loss ratio for {{ $labels.target }} is {{ $value }}"
+    - alert: HighPingRtt
+      expr: round(ping_rtt_mean_seconds * 1000, 0.1) > 100
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: High ping latency for {{ $labels.target }}
+        description: "Ping latency for {{ $labels.target }} is {{ $value }} seconds"

--- a/dist/charts/ping-exporter/files/prometheus.rules
+++ b/dist/charts/ping-exporter/files/prometheus.rules
@@ -1,11 +1,11 @@
     - alert: HighPingLossRatio
-      expr: round(ping_loss_ratio * 100) > 0
+      expr: round(ping_loss_ratio * 100) > 5
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: High ping loss ratio for {{ $labels.target }}
-        description: "Ping loss ratio for {{ $labels.target }} is {{ $value }}"
+        description: "Ping loss ratio for {{ $labels.target }} is {{ $value }}%"
     - alert: HighPingRtt
       expr: round(ping_rtt_mean_seconds * 1000, 0.1) > 100
       for: 5m

--- a/dist/charts/ping-exporter/templates/prometheusrule.yaml
+++ b/dist/charts/ping-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: service-prometheus
+    role: alert-rules
+  name: {{ include "ping_exporter.fullname" . }}
+spec:
+  groups:
+  - name: ping_exporter.rules
+    rules:
+{{ .Files.Get "files/prometheus.rules" }}
+{{- end }}

--- a/dist/charts/ping-exporter/templates/servicemonitor.yaml
+++ b/dist/charts/ping-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ping_exporter.fullname" . }}
+  labels:
+    {{- include "ping_exporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ping_exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: http
+    interval: 60s
+    relabelings:
+      - action: labeldrop
+        regex: pod
+        sourceLabels: []
+      - action: labeldrop
+        regex: namespace
+        sourceLabels: []
+      - action: labeldrop
+        regex: instance
+        sourceLabels: []
+      - action: labeldrop
+        regex: job
+        sourceLabels: []
+{{- end }}

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -105,3 +105,7 @@ config:
 # Create a serviceMonitor resource to be consumed by Prometheus Operator
 serviceMonitor:
   enabled: false
+
+# Create basic Prometheus alerting rules
+prometheusRules:
+  enabled: false

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -101,3 +101,7 @@ config:
     timeout: 3s
     history-size: 42
     payload-size: 120
+
+# Create a serviceMonitor resource to be consumed by Prometheus Operator
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
Hi there, I started using this project recently so I decided to contribute support for the Prometheus Operator. This change only affects the Helm chart, but allows seamless integration for people using Kubernetes and the Prometheus Operator.

Setting `serviceMonitor.enabled: true` creates a serviceMonitor resource which makes Prometheus start scraping the exporter.

Setting `prometheusRules.enabled: true` adds some basic Prometheus alerting rules which alert on high latency or high packet loss.

This is tested & working on my Prometheus Operator stack.

Do you need me to bump the chart version before you merge?