### PR TITLE
feat(helm): set up deploy template to flex between deployment and daemonset

### DIFF
--- a/dist/charts/ping-exporter/templates/deploy.yaml
+++ b/dist/charts/ping-exporter/templates/deploy.yaml
@@ -1,13 +1,15 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.type}}
 metadata:
   name: {{ include "ping_exporter.fullname" . }}
   labels:
     {{- include "ping_exporter.labels" . | nindent 4 }}
 spec:
+  {{- if eq .Values.type "Deployment" }}
   replicas: {{ .Values.replicaCount }} 
   strategy: 
   {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ping_exporter.selectorLabels" . | nindent 6 }}

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+type: DaemonSet
+
 image:
   repository: czerwonk/ping_exporter
   pullPolicy: IfNotPresent


### PR DESCRIPTION
I have a situation where i'd like to deploy this chart as a daemonset rather than a deployment. a slight tweak to both values.yaml and the (newly renamed) deploy.yaml provides this flexibility