### PR TITLE
chore(helm/servicemonitor): modify servicemonitor to make relabelings flexible

### DIFF
--- a/dist/charts/ping-exporter/templates/servicemonitor.yaml
+++ b/dist/charts/ping-exporter/templates/servicemonitor.yaml
@@ -13,16 +13,5 @@ spec:
   - port: http
     interval: 60s
     relabelings:
-      - action: labeldrop
-        regex: pod
-        sourceLabels: []
-      - action: labeldrop
-        regex: namespace
-        sourceLabels: []
-      - action: labeldrop
-        regex: instance
-        sourceLabels: []
-      - action: labeldrop
-        regex: job
-        sourceLabels: []
+    {{ .Values.serviceMonitor.relabelings | toYaml | nindent 6 }}
 {{- end }}

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -105,6 +105,20 @@ config:
 # Create a serviceMonitor resource to be consumed by Prometheus Operator
 serviceMonitor:
   enabled: false
+  additionalRelabeling:
+  - action: labeldrop
+    regex: pod
+    sourceLabels: []
+  - action: labeldrop
+    regex: namespace
+    sourceLabels: []
+  - action: labeldrop
+    regex: instance
+    sourceLabels: []
+  - action: labeldrop
+    regex: job
+    sourceLabels: []
+
 
 # Create basic Prometheus alerting rules
 prometheusRules:


### PR DESCRIPTION
this update exposes the relabelings field for targets to `values.yaml` and sets defaults as they are set in the template on main. 

this allows users to either use the defaults as the original template author intended, or update the relabelings to fit their environment.

would appreciate this and #121  being merged before anyone takes action on #119 if possible