### PR TITLE
chore(dev): add makefile and skaffold bits for dev loop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+dev
+dist
+snap
+.github
+LICENSES
+LICENSE
+CODEOWNERS
+README.md

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ NAME: ping-exporter
 | tolerations | list | `[]` | [Tolerations] | 
 
 
+### Kubernetes Dev Loop
+
+`./dev` contains a `Makefile` and targets to start a devloop from sractch with kind.
+
+running `make dev` from inside `./dev` will bring up a kind cluster and start a skaffold dev loop against it
+
+if you're trying to dev against the `serviceMonitor`, you will need to install the `prometheus-community/prometheus-operator-crds` chart at a minimum to get that template to render.
+
 ## Changes from previous versions
 
 ### `ping_loss_ratio` vs `ping_loss_percent`

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,18 @@
+KIND            := kindest/node:v1.27.3
+KIND_CLUSTER    := local-dev-cluster
+
+dev-up:
+	kind create cluster \
+		--image $(KIND) \
+		--name $(KIND_CLUSTER) \
+		--config kind-config.yaml
+
+	kubectl wait --timeout=120s --namespace=local-path-storage --for=condition=Available deployment/local-path-provisioner
+
+dev-down:
+	kind delete cluster --name $(KIND_CLUSTER)
+
+skaffold-dev:
+	skaffold dev --port-forward -f skaffold-dev.yaml
+
+dev: dev-up skaffold-dev dev-down

--- a/dev/kind-config.yaml
+++ b/dev/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/dev/skaffold-dev.yaml
+++ b/dev/skaffold-dev.yaml
@@ -1,0 +1,34 @@
+apiVersion: skaffold/v4beta7
+kind: Config
+metadata:
+  name: ping_exporter
+build:
+  artifacts:
+    - image: localhost/ping_exporter
+      context: ../
+      docker:
+        dockerfile: ../Dockerfile
+deploy:
+  helm:
+    releases:
+      - name: ping-exporter
+        chartPath: ../dist/charts/ping-exporter
+        createNamespace: true
+        setValueTemplates:
+          image.repository: "{{.IMAGE_DOMAIN_localhost_ping_exporter}}/{{.IMAGE_REPO_NO_DOMAIN_localhost_ping_exporter}}"
+          image.tag: "{{.IMAGE_TAG_localhost_ping_exporter}}"
+        setValues:
+          image:
+            pullPolicy: Never
+          serviceMonitor:
+            enabled: true
+            additionalRelabeling: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000


### PR DESCRIPTION
this PR adds some convenience tooling whereby devs can start a dev loop with skaffold and kind to test their changes in kubernetes.

this is not a feature and completely optional to merge