### PR TITLE
feat(helm): add nodeSelector, affinity, and tolerations to test-connection …

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ NAME: ping-exporter
 | serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | serviceAccount.name | string | `""` | Overrides the application's service account name which defaults to `"ping-exporter.fullname"` |
 | tolerations | list | `[]` | [Tolerations] | 
+| testConnection.enabled | bool | `true` | Enable the test connection pod for the ping_exporter
 
 
 ## Changes from previous versions

--- a/dist/charts/ping-exporter/templates/tests/test-connection.yaml
+++ b/dist/charts/ping-exporter/templates/tests/test-connection.yaml
@@ -1,3 +1,5 @@
+
+{{- if .Values.testConnection.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +15,16 @@ spec:
       command: ['wget']
       args: ['{{ include "ping_exporter.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dist/charts/ping-exporter/values.yaml
+++ b/dist/charts/ping-exporter/values.yaml
@@ -109,3 +109,6 @@ serviceMonitor:
 # Create basic Prometheus alerting rules
 prometheusRules:
   enabled: false
+
+testConnection:
+  enabled: true


### PR DESCRIPTION
I have a situation where i'd like to deploy this chart into namespace and deployment annotated for running on nen schedule-able nodes with specified affinity or/and nodeSelector or/and tolerations. Those parameters are accepted and correctly processed in deployment but not in test connection pod where are added by following implementation. In order to have option to enable/disable test connection pod I added also configuration option into values file