### PR TITLE
feat(ping_exporter): add dns resolution timeout option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	DNS struct {
 		Refresh    duration `yaml:"refresh"`
 		Nameserver string   `yaml:"nameserver"`
+		Timeout    duration `yaml:"timeout"`
 	} `yaml:"dns"`
 
 	Options struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,9 @@ func TestParseConfig(t *testing.T) {
 	if expected := 2*time.Minute + 15*time.Second; time.Duration(c.DNS.Refresh) != expected {
 		t.Errorf("expected dns.refresh to be %v, got %v", expected, c.DNS.Refresh)
 	}
+	if expected := 5 * time.Second; time.Duration(c.DNS.Timeout) != expected {
+		t.Errorf("expected dns.timeout to be %v, got %v", expected, c.DNS.Timeout)
+	}
 	if expected := "1.1.1.1"; c.DNS.Nameserver != expected {
 		t.Errorf("expected dns.nameserver to be %q, got %q", expected, c.DNS.Nameserver)
 	}

--- a/config/testdata/config_test.yml
+++ b/config/testdata/config_test.yml
@@ -9,6 +9,7 @@ targets:
 dns:
   refresh: 2m15s
   nameserver: 1.1.1.1
+  timeout: 5s
 
 ping:
   interval: 2s


### PR DESCRIPTION
closes #134 

when running with `--dns.timeout=3s` you get the following output:

```
time="2025-03-31T21:07:12Z" level=info msg="rtt units: 2" func=main.main file="/go/ping_exporter/main.go:94"
time="2025-03-31T21:07:12Z" level=info msg="DNS timeout enabled: using 3000000000" func="main.(*target).addOrUpdateMonitor" file="/go/ping_exporter/target.go:93"
time="2025-03-31T21:07:12Z" level=info msg="DNS timeout enabled: using 3000000000" func="main.(*target).addOrUpdateMonitor" file="/go/ping_exporter/target.go:93"
time="2025-03-31T21:07:12Z" level=info msg="DNS timeout enabled: using 3000000000" func="main.(*target).addOrUpdateMonitor" file="/go/ping_exporter/target.go:93"
time="2025-03-31T21:07:12Z" level=info msg="adding target for host 2001:4860:4860::8844 ({2001:4860:4860::8844 })" func="main.(*target).add" file="/go/ping_exporter/target.go:149"
time="2025-03-31T21:07:12Z" level=info msg="DNS timeout enabled: using 3000000000" func="main.(*target).addOrUpdateMonitor" file="/go/ping_exporter/target.go:93"
time="2025-03-31T21:07:12Z" level=info msg="adding target for host 2001:4860:4860::8888 ({2001:4860:4860::8888 })" func="main.(*target).add" file="/go/ping_exporter/target.go:149"
time="2025-03-31T21:07:12Z" level=info msg="adding target for host 8.8.8.8 ({8.8.8.8 })" func="main.(*target).add" file="/go/ping_exporter/target.go:149"
time="2025-03-31T21:07:12Z" level=info msg="DNS timeout enabled: using 3000000000" func="main.(*target).addOrUpdateMonitor" file="/go/ping_exporter/target.go:93"
time="2025-03-31T21:07:12Z" level=info msg="adding target for host 8.8.4.4 ({8.8.4.4 })" func="main.(*target).add" file="/go/ping_exporter/target.go:149"
time="2025-03-31T21:07:15Z" level=error msg="failed to setup target: error resolving target 'google.com': lookup google.com: i/o timeout" func=main.upsertTargets.func1 file="/go/ping_exporter/main.go:202"
time="2025-03-31T21:07:15Z" level=info msg="Starting ping exporter (Version: 1.1.3)" func=main.startServer file="/go/ping_exporter/main.go:297"
time="2025-03-31T21:07:15Z" level=info msg="Listening for /metrics on :9427 (HTTP)" func=main.startServer file="/go/ping_exporter/main.go:333"
```

the logging can be moved / removed to clean that up if we want