### PR TITLE
fix: use struct field for deprecated metrics and guard against division by zero

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -81,8 +81,12 @@ func (p *pingCollector) Collect(ch chan<- prometheus.Metric) {
 		targetConfig := p.cfg.TargetConfigByAddr(l[0])
 		l = append(l, p.customLabels.labelValues(targetConfig)...)
 
+		if metrics.PacketsSent == 0 {
+			continue
+		}
+
 		if metrics.PacketsSent > metrics.PacketsLost {
-			if enableDeprecatedMetrics {
+			if p.enableDeprecatedMetrics {
 				p.rttDesc.Collect(ch, metrics.Best, append(l, "best")...)
 				p.rttDesc.Collect(ch, metrics.Worst, append(l, "worst")...)
 				p.rttDesc.Collect(ch, metrics.Mean, append(l, "mean")...)


### PR DESCRIPTION
Two fixes in Collect():
1. Use p.enableDeprecatedMetrics (struct field) instead of the
   package-level enableDeprecatedMetrics variable, matching the
   pattern already used in Describe().
2. Skip targets with PacketsSent == 0 to avoid emitting NaN for
   the loss metric (0/0 in IEEE 754).