### PR TITLE
fix: check net.ParseIP result in K8sResolver to prevent nil IP

### DIFF
--- a/k8sresolver.go
+++ b/k8sresolver.go
@@ -46,8 +46,10 @@ func (r *K8sResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAd
 	for _, subset := range endpoints.Subsets {
 		for _, addr := range subset.Addresses {
 			_ip := net.ParseIP(addr.IP)
-			ip := net.IPAddr{IP: _ip}
-			ips = append(ips, ip)
+			if _ip == nil {
+				continue
+			}
+			ips = append(ips, net.IPAddr{IP: _ip})
 		}
 	}
 


### PR DESCRIPTION
If a Kubernetes Endpoint returns a malformed IP string, net.ParseIP
returns nil. A nil IP in the returned slice would cause unexpected
behavior downstream in the pinger. Skip invalid addresses.