### PR TITLE
fix(packaging): run maintainer scripts on rpm and fix SELinux label

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ nfpms:
     file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if eq .Mips "softfloat" }}sf{{ end }}'
 
     formats:
-      - rpm # TODO: create pre/post install/remove scripts
+      - rpm
       - deb
 
     bindir: /usr/bin
@@ -81,12 +81,10 @@ nfpms:
       - dst: /run/systemd/system/ping_exporter.service.d
         type: dir
 
-    overrides:
-      deb:
-        scripts:
-          postinstall:  dist/postinstall.sh
-          preremove:    dist/preremove.sh
-          postremove:   dist/postremove.sh
+    scripts:
+      postinstall:  dist/postinstall.sh
+      preremove:    dist/preremove.sh
+      postremove:   dist/postremove.sh
 
 changelog:
   sort: asc

--- a/dist/postinstall.sh
+++ b/dist/postinstall.sh
@@ -5,10 +5,24 @@ useradd --system -d /nonexistent -s /usr/sbin/nologin -g ping_exporter ping_expo
 
 chown ping_exporter /etc/ping_exporter/config.yml
 
-current_systemd_version=$(dpkg-query --showformat='${Version}' --show systemd)
+# The base SELinux policy labels /usr/bin/ping* as ping_exec_t, which systemd
+# may not execute (AVC denial "execute_no_trans"), so pin the binary to bin_t.
+if command -v selinuxenabled >/dev/null 2>&1 && selinuxenabled; then
+	if command -v semanage >/dev/null 2>&1; then
+		semanage fcontext -a -t bin_t '/usr/bin/ping_exporter' 2>/dev/null ||
+			semanage fcontext -m -t bin_t '/usr/bin/ping_exporter' 2>/dev/null ||
+			true
+	fi
+
+	if command -v restorecon >/dev/null 2>&1; then
+		restorecon -F /usr/bin/ping_exporter || true
+	fi
+fi
+
+current_systemd_version=$(systemctl --version | sed -n '1s/^systemd v\{0,1\}\([0-9]\{1,\}\).*/\1/p')
 
 for v in 233 235 242 245; do
-	if dpkg --compare-versions "$current_systemd_version" ge "$v"; then
+	if [ -n "$current_systemd_version" ] && [ "$current_systemd_version" -ge "$v" ]; then
 		cp /usr/local/share/ping_exporter/systemd-$v.conf /run/systemd/system/ping_exporter.service.d/
 	fi
 done

--- a/dist/postremove.sh
+++ b/dist/postremove.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
-if [ "$1" != "remove" ]; then
-	exit 0
-fi
+case "$1" in
+remove | purge | 0) ;;
+*) exit 0 ;;
+esac
 
 systemctl daemon-reload
+
+if command -v semanage >/dev/null 2>&1; then
+	semanage fcontext -d '/usr/bin/ping_exporter' 2>/dev/null || true
+fi
+
 userdel  ping_exporter || true
 groupdel ping_exporter 2>/dev/null || true

--- a/dist/preremove.sh
+++ b/dist/preremove.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-if [ "$1" != "remove" ]; then
-	exit 0
-fi
+# dpkg passes "remove", rpm passes "0"; anything else is an upgrade.
+case "$1" in
+remove | 0) ;;
+*) exit 0 ;;
+esac
 
 systemctl disable ping_exporter || true
 systemctl stop ping_exporter    || true


### PR DESCRIPTION
Fixes #152

Two separate things are wrong with the RPM, and they compound.

**No scriptlets.** In `.goreleaser.yml` the `scripts:` block sits under `overrides: deb:`, so only the .deb gets `postinstall`/`preremove`/`postremove`. The RPM ships without any — `rpm -q --scripts ping_exporter` is empty, as the reporter shows. The `ping_exporter` user the unit requires is never created, the config is never chowned, and the systemd drop-ins are never copied. I moved the block up one level so it applies to every format, and dropped the `# TODO: create pre/post install/remove scripts` note next to `rpm`.

That only works if the scripts stop assuming dpkg, so:

- the systemd version now comes from `systemctl --version` instead of `dpkg-query`. Same drop-in selection as before on Debian (252 picks 233/235/242/245, 232 picks none), and it also works on RHEL.
- `preremove`/`postremove` accept rpm's numeric `$1` (`0` = uninstall) alongside dpkg's `remove`. Without this both would exit early on RPM and never stop the unit or remove the user.

**Wrong SELinux label.** This is what actually produces the `203/EXEC` in the issue. Missing users fail earlier, at `217/USER`; the audit log in the report points elsewhere:

```
avc: denied { execute_no_trans } for comm="(exporter)" path="/usr/bin/ping_exporter"
  scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:ping_exec_t:s0
```

The base policy ships `/bin/ping.*  system_u:object_r:ping_exec_t:s0`, and `/usr/bin/ping_exporter` matches that regex, so the binary inherits `ping_exec_t`, which systemd may not execute. `postinstall` now pins it to `bin_t` and relabels; `postremove` drops the file context on uninstall. Both are guarded on `selinuxenabled`/`semanage`/`restorecon` existing, so hosts without SELinux tooling are unaffected. I chose `bin_t` over leaving it in `ping_t` deliberately: the same audit log shows `ping_t` being denied `listen` on a tcp_socket, so the exporter could not serve metrics even if it did start.

**Verified:** `shellcheck -s sh` clean on all three scripts; the version parser checked against seven real `systemctl --version` formats (el8/el9, arch, deb11, ubuntu, 232); the `$1` matrix for both package managers; and a dry run of `postinstall` with `systemctl`/`semanage`/`restorecon` mocked, confirming the Debian drop-in selection is unchanged.

**Not verified:** I have no goreleaser, nfpm or rpm locally and no enforcing RHEL host, so I could not build the packages or install one. The packaging change is the part that needs your CI.